### PR TITLE
支持中英混合语言

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ wheels/
 .vscode/
 *.swp
 *.swo
+
+# MacOS
+.DS_Store

--- a/src/genie_tts/GetPhonesAndBert.py
+++ b/src/genie_tts/GetPhonesAndBert.py
@@ -1,10 +1,59 @@
 import numpy as np
-from typing import Tuple
+import re
+from typing import Tuple, Literal
 from .Utils.Constants import BERT_FEATURE_DIM
 from .ModelManager import model_manager
 
+def split_language(text: str) -> list[dict[Literal['language', 'content'], str]]:
+    """
+    从文本中提取中文和英文部分，返回一个包含语言和内容的列表。
+
+    ### 参数:
+    text (str): 输入的文本，包含中文和英文混合。
+
+    ### 返回:
+    list[dict[Literal['language', 'content'], str]]: 一个列表，每个元素是一个字典，包含语言（'chinese'或'english'）和对应的内容。
+    """
+
+    pattern_eng = re.compile(r"[a-zA-Z]+")
+    split = re.split(pattern_eng, text)
+    matches = pattern_eng.findall(text)
+
+    assert len(matches) == len(split) - 1, "Mismatch between number of English matches and Chinese parts"
+
+    result = []
+    for i, part in enumerate(split):
+        if part.strip():
+            result.append({'language': 'chinese', 'content': part})
+        if i < len(matches):
+            result.append({'language': 'english', 'content': matches[i]})
+
+    return result
 
 def get_phones_and_bert(prompt_text: str, language: str = 'japanese') -> Tuple[np.ndarray, np.ndarray]:
+    """获取 phones 序列和 bert 特征, 考虑混合语言问题"""
+
+    if language.lower() == 'hybrid-chinese-english':
+        split = split_language(prompt_text)
+
+        list_phones = []
+        list_berts = []
+
+        for chunk in split:
+            phones_seq, text_bert = _get_phones_and_bert_pure_lang(chunk['content'], chunk['language'])
+            list_phones.append(phones_seq)
+            list_berts.append(text_bert)
+
+        phones_seq = np.concatenate(list_phones, axis=1)
+        text_bert = np.concatenate(list_berts, axis=0)
+    else:
+        phones_seq, text_bert = _get_phones_and_bert_pure_lang(prompt_text, language)
+
+    return phones_seq, text_bert
+
+def _get_phones_and_bert_pure_lang(prompt_text: str, language: str = 'japanese') -> Tuple[np.ndarray, np.ndarray]:
+    """获取 phones 序列和 bert 特征，不考虑混合语言问题"""
+
     if language.lower() == 'english':
         from .G2P.English.EnglishG2P import english_to_phones
         phones = english_to_phones(prompt_text)

--- a/src/genie_tts/Internal.py
+++ b/src/genie_tts/Internal.py
@@ -107,12 +107,15 @@ def load_character(
     check_onnx_model_dir(onnx_model_dir)
 
     language = normalize_language(language)
-    if language not in ['Japanese', 'English', 'Chinese']:
+    if language not in ['Japanese', 'English', 'Chinese', 'Hybrid-Chinese-English']:
         raise ValueError('Unknown language')
 
     if language == 'Chinese':
         ensure_exists(Chinese_G2P_DIR, "Chinese_G2P_DIR")
     elif language == 'English':
+        ensure_exists(English_G2P_DIR, "English_G2P_DIR")
+    elif language == 'Hybrid-Chinese-English':
+        ensure_exists(Chinese_G2P_DIR, "Chinese_G2P_DIR")
         ensure_exists(English_G2P_DIR, "English_G2P_DIR")
 
     model_path: str = os.fspath(onnx_model_dir)

--- a/src/genie_tts/Utils/Language.py
+++ b/src/genie_tts/Utils/Language.py
@@ -19,6 +19,11 @@ language_map = {
     "jp": "Japanese",
     "ja": "Japanese",
     "nihongo": "Japanese",
+
+    # Hybrid
+    "hybrid": "Hybrid-Chinese-English",
+    "hybrid-zh-en": "Hybrid-Chinese-English",
+    "hybrid-en-zh": "Hybrid-Chinese-English",
 }
 
 


### PR DESCRIPTION
实现了中英混合语言，通过在load_character的时候将language设为“hybrid”或“hybrid-zh-en”来使用；
实现思路是，在get_phones_and_berts时，先将文本拆分为段，每一段内只包含一种语言，然后对每一段分别按照其语种计算phones和berts，最后拼接在一起