### PR TITLE
fix: Python version requirement to match onnxruntime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,12 @@ authors = [
 ]
 description = "GPT-SoVITS ONNX Inference Engine & Model Converter"
 # readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Changes
- Update `requires-python` from `>=3.9` to `>=3.10` to match `onnxruntime==1.22.1` requirement
- Remove Python 3.9 classifier from the list

## Reason
The previous configuration caused dependency resolution failures when using Python 3.9, as onnxruntime requires Python >=3.10. This change ensures compatibility and allows `uv sync` to succeed.

## Testing
- Verified that `uv sync` now works on Python 3.12
- All dependencies build successfully